### PR TITLE
Fixed Issue That "All Store Views" Option Did Not Work

### DIFF
--- a/app/code/community/MagentoHackathon/AdvancedAcl/Block/Adminhtml/Permissions/Tab/Stores.php
+++ b/app/code/community/MagentoHackathon/AdvancedAcl/Block/Adminhtml/Permissions/Tab/Stores.php
@@ -59,8 +59,7 @@ class MagentoHackathon_AdvancedAcl_Block_Adminhtml_Permissions_Tab_Stores
                 'name'      => 'stores[]',
                 'label'     => Mage::helper('cms')->__('Store View'),
                 'title'     => Mage::helper('cms')->__('Store View'),
-                'required'  => true,
-                'values'    => Mage::getSingleton('adminhtml/system_store')->getStoreValuesForForm(false, true),
+                'values'    => Mage::getSingleton('adminhtml/system_store')->getStoreValuesForForm(),
             ));
             $renderer = $this->getLayout()->createBlock('adminhtml/store_switcher_form_renderer_fieldset_element');
             $field->setRenderer($renderer);


### PR DESCRIPTION
Previously, the store views field was required when editing an admin role. If you selected "All Store Views", the user should see all orders/invoices/etc. Unfortunately, the user did not see any of them, because the filter was applied to the collection with a store_id of 0. Hence, I made the field optional and hided the "All Store Views" option. If you do not select any store view, no filter is applied. This is also what the README says:

    If none is selected, the role access won't get limited.