### PR TITLE
only append store ID if access is restricted

### DIFF
--- a/app/code/community/MagentoHackathon/AdvancedAcl/Model/Observer/Url.php
+++ b/app/code/community/MagentoHackathon/AdvancedAcl/Model/Observer/Url.php
@@ -24,7 +24,7 @@ class MagentoHackathon_AdvancedAcl_Model_Observer_Url extends
         $defaultStoreId = $this->getHelper()->getDefaultStoreId();
         $allowedStoreIds = $this->getHelper()->getAllowedStoreIds();
 
-        if (is_null($storeId) && !in_array($defaultStoreId, $allowedStoreIds)) {
+        if (is_null($storeId) && !empty($allowedStoreIds) && !in_array($defaultStoreId, $allowedStoreIds)) {
             $storeId = current($allowedStoreIds);
             $controller->getRequest()->setParam(self::STORE_PARAM_KEY, $storeId);
         }


### PR DESCRIPTION
If `$allowedStoreIds` is empty, the access should not be restricted. Hence, no store ID should be set. Otherwise, the user is always redirected to the wrong (default) store.